### PR TITLE
Parallel replications, using the foreach() %dopar% {} construct instead of for() {} in validate() function.

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,2 @@
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata

--- a/BayesValidate.Rproj
+++ b/BayesValidate.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: BayesValidate
-Version: 0.1
+Version: 0.2
 Date: 2018-01-29
 Title: BayesValidate Package
 Authors@R: c(person("Samantha", "Cook", email = "cook@stat.columbia.edu",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,11 @@
 Package: BayesValidate
-Version: 0.0
-Date: 2005-06-25
+Version: 0.1
+Date: 2018-01-29
 Title: BayesValidate Package
-Author: Samantha Cook <cook@stat.columbia.edu>.
+Authors@R: c(person("Samantha", "Cook", email = "cook@stat.columbia.edu",
+                 role = c("aut", "cre", "cph")),
+             person("Venelin", "Mitov", email = "vmitov@gmail.com",
+                 role = c("ctb")))
 Maintainer: Samantha Cook <cook@stat.columbia.edu>
 Depends: R (>= 2.0.1)
 Description: BayesValidate implements the software validation method
@@ -13,6 +16,7 @@ Description: BayesValidate implements the software validation method
         being fit, and repeatedly generates and analyzes data to check
         that the Bayesian inference program works properly.
 License: GPL (>= 2)
+Imports: foreach
 Packaged: Thu Mar 30 10:48:35 2006; hornik
 Repository: CRAN
 Date/Publication: 2006-03-30 09:22:53

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,3 +1,6 @@
+importFrom(foreach,"%do%")
+importFrom(foreach,"%dopar%")
+importFrom(foreach,foreach)
 export(quant,validate)
 
 

--- a/R/validate.R
+++ b/R/validate.R
@@ -1,7 +1,7 @@
 validate <- function ( generate.param, generate.param.inputs=NULL, 
 	generate.data, generate.data.inputs=NULL, analyze.data, 
 	analyze.data.inputs=NULL, n.rep=20,n.batch=NULL,params.batch=NULL,parallel.rep=FALSE, 
-	print.reps=FALSE, return.all = FALSE, add.to=NULL) {
+	print.reps=FALSE, return.all = FALSE, add.to=NULL, plot.title=NULL) {
 
 #----------------------------------------------------------------------------
 #        Inputs
@@ -70,6 +70,9 @@ validate <- function ( generate.param, generate.param.inputs=NULL,
 #       except for n.rep, which can be different. Specifying n.rep = 0 allows to redo 
 #       the analysis (z-values and p-values) on the posterior quantiles found in add.to.
 #       Default setting is NULL.
+# plot.title            : a character string or an expression used for the title of
+#       the absolute-z statistic plot. Default is NULL resulting in the title being
+#       set to expression("Absolute "*z[theta]*" Statistics").
 #
 #-----------------------------------------------------------------------------
 #
@@ -244,9 +247,13 @@ else {
 print(paste("Smallest Bonferonni-adjusted p-value: ", round(adj.min.p, 3)))
 
 ##plot
+plot.title <- if(is.null(plot.title)) 
+  expression("Absolute "*z[theta]*" Statistics") else plot.title
+
 if(is.null(n.batch)){
 	plot(z.stats, rep(1,n.param), xlim=c(0,upper.lim),xlab="",
-		ylab="",main=expression("Absolute "*z[theta]*" Statistics"),
+		ylab="",
+		main=plot.title,
 		axes=F)
 	axis(1,line=.1)} else {
 	##first plot parameters that are NOT batch means
@@ -254,7 +261,7 @@ if(is.null(n.batch)){
 	plot(z.stats[1:n.param][plot.batch%in%rows.one==FALSE],
 		plot.batch[plot.batch%in%rows.one==FALSE],
 		xlim=c(0,upper.lim),ylim=c(1,num.batches),xlab="",
-		ylab="",main=expression("Absolute "*z[theta]*" Statistics"),
+		ylab="",main=plot.title,
 		axes=F,pch=1)
 	##now add batch means
 	points(z.batch,c(1:num.batches),pch=20)

--- a/man/validate.Rd
+++ b/man/validate.Rd
@@ -30,7 +30,9 @@ validate(generate.param, generate.param.inputs = NULL, generate.data,
 	! This is the software being tested !! }
   \item{analyze.data.inputs}{ Inputs to the function analyze.data (in addition to 
 	data.rep and theta.true) }
-  \item{n.rep}{ Number of replications to be performed, default is 20. }
+  \item{n.rep}{ Number of replications to be performed, default is 20. If set to 0, 
+  the validation execution is skipped and the analysis is performed on the posterior
+  quantiles in add.to.}
   \item{n.batch}{ Lengths of parameter batches.  A parameter batch might consist of, 
 	for example, all person-level means in a hierarchical model or any group of 
 	parameters that is sampled in a loop.  Must sum to n.param (length of parameter

--- a/man/validate.Rd
+++ b/man/validate.Rd
@@ -52,6 +52,11 @@ validate(generate.param, generate.param.inputs = NULL, generate.data,
 	of the posterior quantiles for a given parameters.
   Default is FALSE, meaning that only a list of p.vals, adj.min.p and where
   appropriate, p.batch, will be returned. }
+  \item{add.to}{a list returned by a previous call to validate with 
+   return.all set to TRUE. This allows to add new replications to a previous
+   validation test and calculate the test statistics on the fly. The previous
+   call should have been performed with the same values for the other arguments,
+   except for n.rep, which can be different. Default is NULL.}
 }
 \details{
 \code{Validate} tests whether

--- a/man/validate.Rd
+++ b/man/validate.Rd
@@ -41,8 +41,17 @@ validate(generate.param, generate.param.inputs = NULL, generate.data,
 	Must have length equal to the number of batches.  Can consist of text (e.g., 
 	params.batch=c("alpha","beta")) or an expression (e.g., 
 	params.batch=expression(alpha,beta)).  Not used if n.batch not provided. }
+  \item{parallel.rep}{logical indicating whether the replications should be executed 
+  in parallel using the "foreach() \%dopar\% {}" construct. Defaults to FALSE. The
+  user should create a parallel cluster before calling validate and destroy the 
+  cluster after validate has finished.}
   \item{print.reps}{ Indcator of whether or not to print the replication number, 
 	default is FALSE }
+	\item{return.all}{ Indicator whether or not to return a list with all variables; 
+	can be used for debugging or for further analysis, such as plotting a histogram
+	of the posterior quantiles for a given parameters.
+  Default is FALSE, meaning that only a list of p.vals, adj.min.p and where
+  appropriate, p.batch, will be returned. }
 }
 \details{
 \code{Validate} tests whether
@@ -195,5 +204,18 @@ tst.2 <- validate(generate.param = generate.param, generate.param.inputs =
 	analyze.data.error2, analyze.data.inputs = analyze.data.inputs, 
 	n.rep = 20, params.batch = expression(sigma^2,mu), n.batch = c(1,1))
 
+## executing the replications in parallel (uncomment the commented R-code below)
+## set up a parallel cluster on the local computer for parallel MCMC:
+# cluster <- parallel::makeCluster(parallel::detectCores(logical = TRUE))
+# doParallel::registerDoParallel(cluster)
+# tst.2 <- validate(generate.param = generate.param, generate.param.inputs = 
+#	  generate.param.inputs, generate.data = generate.data, 
+#	  generate.data.inputs = generate.data.inputs, analyze.data = 
+#	  analyze.data.error2, analyze.data.inputs = analyze.data.inputs, 
+#	  n.rep = 20, params.batch = expression(sigma^2,mu), n.batch = c(1,1),
+#   parallel.rep = TRUE
+# )
+## Don't forget to destroy the parallel cluster to avoid leaving zombie worker-processes.
+# parallel::stopCluster(cluster)
 }
 \keyword{debugging}

--- a/man/validate.Rd
+++ b/man/validate.Rd
@@ -8,7 +8,8 @@
 \usage{
 validate(generate.param, generate.param.inputs = NULL, generate.data, 
 	generate.data.inputs = NULL, analyze.data, analyze.data.inputs = NULL, 
-	n.rep = 20, n.batch = NULL, params.batch = NULL, print.reps = FALSE)
+	n.rep = 20, n.batch = NULL, params.batch = NULL,parallel.rep=FALSE, print.reps = FALSE,
+	return.all = FALSE, add.to=NULL, plot.title=NULL)
 }
 \arguments{
   \item{generate.param}{ Function for generating parameters from prior distribution
@@ -59,6 +60,9 @@ validate(generate.param, generate.param.inputs = NULL, generate.data,
    validation test and calculate the test statistics on the fly. The previous
    call should have been performed with the same values for the other arguments,
    except for n.rep, which can be different. Default is NULL.}
+  \item{plot.title}{a character string or an expression used for the title of
+        the absolute-z statistic plot. Default is NULL resulting in the title being
+        set to expression("Absolute "*z[theta]*" Statistics").}
 }
 \details{
 \code{Validate} tests whether


### PR DESCRIPTION
Using the BayesValidate package to validate a potentially long-running MCMC sampling procedure can be extremely slow, in particular, when executing several dozens of replications. I am proposing a way to accelerate this validation using parallel execution on multiple processor systems. 

Best regards, 
Venelin Mitov